### PR TITLE
Add missing dropdown items template and enable it

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,7 @@
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">
                 {% with dropdown=True %}
-                    {% show_menu 0 0 100 100 "includes/menu.html" %}
+                    {% show_menu 0 100 100 100 "includes/menu.html" %}
                 {% endwith %}
             </ul>
         </div>

--- a/templates/includes/dropdown.html
+++ b/templates/includes/dropdown.html
@@ -1,0 +1,7 @@
+{% if child.get_descendants %}
+    {% for node in child.get_descendants %}
+        <a class="dropdown-item"  href="{{ node.attr.redirect_url|default:node.get_absolute_url }}">
+            {{ node.get_menu_title }}
+        </a>
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
Fixes issue #1. 

The template is missing and once I had added I had to enable the children. 

Please let me know if there's any more that needs doing to this. I also have a basic webpack config that enables modifying the JS and SCSS if you feel that would be useful for this boilerplate?